### PR TITLE
handle parallel block sync entierly with Fluture.parallel for blocks

### DIFF
--- a/src/database/sync.database.ts
+++ b/src/database/sync.database.ts
@@ -167,7 +167,7 @@ const processBlockQueue = (
           ? toLong(queueSource.peek().nextHeight)
           : toLong(-1);
 
-      peek.fresolve();
+      peek.fresolve && peek.fresolve();
       if (queueSource.isEmpty() && txQueue.isEmpty()) {
         log.info("import queues have been consumed");
       }

--- a/src/database/sync.database.ts
+++ b/src/database/sync.database.ts
@@ -167,6 +167,7 @@ const processBlockQueue = (
           ? toLong(queueSource.peek().nextHeight)
           : toLong(-1);
 
+      peek.fresolve();
       if (queueSource.isEmpty() && txQueue.isEmpty()) {
         log.info("import queues have been consumed");
       }
@@ -634,10 +635,9 @@ export function storeBlock({
           height: newSyncBlockHeight,
           txCount: newSyncBlock.txs ? newSyncBlock.txs.length : 0,
           nextHeight: toLong(next),
+          fresolve,
           type: "block",
         });
-        fresolve(true);
-        return;
       } else {
         await new Promise((resolve) => setTimeout(resolve, 100));
         if (retry >= 250) {
@@ -650,14 +650,7 @@ export function storeBlock({
     }
 
     blockQueue.sortQueue();
-
-    pWaitFor(
-      () =>
-        blockQueue.isEmpty() ||
-        blockQueue.peek().height.gt(height) ||
-        blockQueue.getSize() < PARALLEL + 1,
-      { interval: 500 }
-    ).then(() => getBlock());
+    getBlock();
 
     return () => {
       isCancelled = true;

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -220,8 +220,10 @@ export async function runGatewayOnce({
   let proc = startGateway();
   proc.stderr.on("data", (log: string) => {
     if (shouldStop(log) && fullySyncPromiseResolve) {
-      fullySyncPromiseResolve = undefined;
-      setTimeout(fullySyncPromiseResolve, 0);
+      setTimeout(() => {
+        fullySyncPromiseResolve();
+        fullySyncPromiseResolve = undefined;
+      }, 0);
     }
 
     logs.push(log);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -217,7 +217,9 @@ export async function runGatewayOnce({
       ? stopCondition(log.toString())
       : /fully synced db/g.test(log.toString()) ||
         /import queues have been consumed/g.test(log.toString());
+
   let proc = startGateway();
+
   proc.stderr.on("data", (log: string) => {
     if (shouldStop(log) && fullySyncPromiseResolve) {
       setTimeout(() => {
@@ -230,6 +232,7 @@ export async function runGatewayOnce({
     process.stderr.write(log);
     onLog && onLog(log);
   });
+
   proc.stdout.on("data", (log: string) => {
     if (shouldStop(log) && fullySyncPromiseResolve) {
       setTimeout(fullySyncPromiseResolve, 0);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -75,7 +75,10 @@ describe("database sync test suite", function () {
       await fs.unlink("./cache/hash_list_test.json");
     }
 
-    const logs = await helpers.runGatewayOnce({});
+    const logs = await helpers.runGatewayOnce({
+      stopCondition: (log) =>
+        log ? /polling for new blocks/.test(log) : false,
+    });
 
     const queryResponse = await client.execute(
       "SELECT COUNT(*) FROM testway.block ALLOW FILTERING"
@@ -270,7 +273,7 @@ describe("graphql test suite", function () {
 
     const runp = helpers.runGatewayOnce({
       stopCondition: (log) => {
-        if (/fully in sync/g.test(log) && resolveReady) {
+        if (/polling for new blocks/g.test(log) && resolveReady) {
           resolveReady();
           resolveReady = undefined;
         }


### PR DESCRIPTION
essentially opens up to remove one pWaitFor blocks, which seems to be cost much in cpu usage..