### PR TITLE
fixs crash in docker-compose due to `./cache` dir missing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,13 @@ services:
       cassandra:
         condition: service_healthy
     restart: unless-stopped
+    volumes:
+      - "cache:/app/cache"
     networks:
       - arlocal
 
 volumes:
   cassandra_data:
+    driver: local
+  cache:
     driver: local


### PR DESCRIPTION
Fix `[Error: ENOENT: no such file or directory, open 'cache/hash_list.json']` when running the gateway in docker compose, caused by `./cache` is ignored and was not create anywhere