### PR TITLE
fix block API cumulative_diff type might be number

### DIFF
--- a/src/query/block.ts
+++ b/src/query/block.ts
@@ -82,6 +82,9 @@ export async function getBlock({
     // REVIEW: does assuming re-forking condition work better than fatal error?
     process.exit(1);
   }
+  if (body.cumulative_diff) { // HACK: Fix some cumulative_diff is number
+    body.cumulative_diff = body.cumulative_diff.toString();
+  }
   warmNode(tryNode);
   return body;
 }


### PR DESCRIPTION
e.g. https://arweave.net/block/height/95001 
but `cumulative_diff` is assumed to be a string in ts and cassandra